### PR TITLE
Fix: Hide password input (show dots instead of visible text)

### DIFF
--- a/src/Components/Login.js
+++ b/src/Components/Login.js
@@ -102,8 +102,7 @@ const Login =() =>{
             className="p-4 my-2 w-full bg-gray-700 rounded-md"
         />
 
-        <input ref={password} 
-               type="text" placeholder="Password" className="p-4 my-2 w-full bg-gray-700 rounded-md"
+        <input ref={password} type="password" placeholder="Password" className="p-4 my-2 w-full bg-gray-700 rounded-md"
         />
             <p className="text-red-500">{errormessage}</p>
         <button className="p-4 my-6 bg-red-700 w-full rounded-lg border-white" 


### PR DESCRIPTION
- This pull request addresses a bug where the password input field displays the entered password as visible text, which compromises user privacy and security.

-  The change ensures that the password input field correctly masks the entered password with dots (or asterisks), following the standard behavior for password fields. 

- This enhancement improves security by preventing unauthorized users from seeing the password while it's being typed.

![image](https://github.com/user-attachments/assets/bc982c87-8226-4b38-b15b-737459e429df)
